### PR TITLE
Melhorias na manutenibilidade das chamadas HTTP do Front e do Back-End.

### DIFF
--- a/client/src/helpers/axiosInstance.js
+++ b/client/src/helpers/axiosInstance.js
@@ -5,7 +5,19 @@ import { store } from '../redux/store';
 import { clearUser } from '../redux/actions'
 
 // Configurações básicas.
-    const axiosInstance = axios.create();
+
+    /**
+     * @default axiosInstance = axios.create({
+     *      baseURL: 'http://localhost:3000'    // Essa instância, por padrão realizará chamadas na REST API.
+     * });
+     * @summary Quando for chamar end-points de outros domínios, declare o domínio nas configurações do axios alterando a propriedade "baseURL". O exemplo abaixo é equivalente à "axios.get("http://localhost:4000/auth/refresh") ".
+     * @example axios.get('/auth/refresh', { 
+     *      baseURL: 'http://localhost:4000'
+     * });
+     */
+    const axiosInstance = axios.create({
+        baseURL: 'http://localhost:3000'    // Essa instância, por padrão realizará chamadas na REST API.
+    });
 
     axiosInstance.interceptors.response.use(null, (error) => {
 
@@ -15,7 +27,8 @@ import { clearUser } from '../redux/actions'
 
         if (code === 'EXPIRED_USER_AUTH' || code === 'AUTH_HEADER_NOT_SENT'){
 
-            return axiosInstance.get('http://localhost:4000/auth/refresh', {
+            return axiosInstance.get('/auth/refresh', {
+                baseURL: 'http://localhost:4000',           // Domínio do Back-end da aplicação.
                 withCredentials: true   // Envia os cookies httpOnly contendo o refreshToken do usuário.
             })
             .then((response) => {

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -15,7 +15,8 @@
 
     import axios from './helpers/axiosInstance';
 
-axios.get('http://localhost:4000/auth/refresh', {
+axios.get('/auth/refresh', {
+    baseURL: 'http://localhost:4000',   // Domínio do Back-end da aplicação.
     withCredentials: true
 })
 .then((response) => {

--- a/client/src/pages/HomeContainer.js
+++ b/client/src/pages/HomeContainer.js
@@ -67,7 +67,8 @@ const Home = (props) => {
 
     const handleLogout = (ev) => {
 
-        axios.get('http://localhost:4000/auth/logout', {
+        axios.get('/auth/logout', {
+            baseURL: 'http://localhost:4000',   // Domínio do Back-end da aplicação.
             withCredentials: true
         })
         .then((response) => {

--- a/client/src/pages/LoginContainer.js
+++ b/client/src/pages/LoginContainer.js
@@ -64,11 +64,12 @@ const LoginContainer = (props) => {
 
         const {email, password, remember} = credentials;
 
-        axios.post('http://localhost:4000/auth/login', {
+        axios.post('/auth/login', {
             email,
             password,
             remember
         }, {
+            baseURL: 'http://localhost:4000',   // Domínio do Back-end da aplicação.
             withCredentials: true
         })
         .then((response) => {

--- a/client/src/redux/user/userActions.js
+++ b/client/src/redux/user/userActions.js
@@ -92,7 +92,7 @@ export const fetchUser = () => {
 
         // });
 
-        axios.get('http://localhost:3000/usuarios/?get=self')
+        axios.get('/usuarios/?get=self')
         .then((response) => {
 
             const user = response.data?.usuario

--- a/server/api/helper/axiosInstance.js
+++ b/server/api/helper/axiosInstance.js
@@ -6,9 +6,19 @@ const { default: axios } = require('axios');
     const refreshUserTokens = require('./refreshUserTokens_stash');
 
 // Configurações básicas.
-    const axiosInstance = axios.create(//{
-        // userAuthRefresh: null   // config onde o Refresh Token do Usuario deve ser passado (Para a renovação silenciosa da sessão ).
-    /*}*/);     // Cria uma instância personalizada do axios.
+
+    /**
+     * @default axiosInstance = axios.create({
+     *      baseURL: 'http://localhost:3000'    // Essa instância, por padrão realizará chamadas na REST API.
+     * });
+     * @summary Quando for chamar end-points de outros domínios, declare o domínio nas configurações do axios alterando a propriedade "baseURL". O exemplo abaixo é equivalente à "axios.get("http://localhost:4000/auth/refresh") ".
+     * @example axios.get('/todos/1', { 
+     *      baseURL: 'https://jsonplaceholder.typicode.com'
+     * });
+     */
+    const axiosInstance = axios.create({
+        baseURL: 'http://localhost:3000'
+    });     // Cria uma instância personalizada do axios.
             // Atenção, não atribua nenhuma configuração padrão além dos interceptors nessa instância.
             // Se não todos os usuários do sistema serão afetados, pois o server utiliza essa instância de forma global.
     

--- a/server/api/helper/refreshClientTokens.js
+++ b/server/api/helper/refreshClientTokens.js
@@ -7,7 +7,7 @@
  * @returns Atualiza os tokens de acesso da aplicação e retorna o Access Token renovado, para continuar as requisições.
  */
 module.exports = () => {
-    return axios.post(`http://127.0.0.1:3000/autenticacoes/apis/refresh`, {
+    return axios.post(`/autenticacoes/apis/refresh`, {
         refreshToken: process.env.CLIENT_RT
     })
     .then(async (res) => {
@@ -30,7 +30,7 @@ module.exports = () => {
 
             if (error.response.data.error.code === 'EXPIRED_CLIENT_REFRESH'){
                 // Se o Refresh Token do Cliente estiver expirado, renove-o autenticand-se novamente.
-                axios.get(`http://127.0.0.1:3000/autenticacoes/apis/login/?cliente=${process.env.MY_REST_APP_ID}&senha=${process.env.MY_REST_APP_PASS}`)
+                axios.get(`/autenticacoes/apis/login/?cliente=${process.env.MY_REST_APP_ID}&senha=${process.env.MY_REST_APP_PASS}`)
                 .then(async (res) => {
 
                     if (res.status == 200 && res.data?.client_accessToken){

--- a/server/api/middlewares/validate_userTokens.js
+++ b/server/api/middlewares/validate_userTokens.js
@@ -52,7 +52,7 @@ module.exports = async (req, res, next) => {
         console.log('\n[validate_userTokens] A requisição possui apenas um httpOnly Cookie apresentando o refresh token. Iniciando tentativa de renovação dos JWTs antes de continuar a requisição...');
     }
 
-    const refreshedTokens = await axios.post(`http://127.0.0.1:3000/autenticacoes/usuarios/refresh`, {
+    const refreshedTokens = await axios.post(`/autenticacoes/usuarios/refresh`, {
         refreshToken: req.cookies.auth_refresh
     }, {
         headers: {
@@ -152,7 +152,7 @@ module.exports = async (req, res, next) => {
                 );
             }
         // Fim da verificação do cookie de persistencia da autenticação do usuário
-        
+
     // Fim da renovação do cabeçalho de requisições e httpOnly Cookie.
 
     // Quando a resposta da requisição for enviada depois desse Middleware, essas alterações entrarão em efeito.

--- a/server/api/routes/auth.js
+++ b/server/api/routes/auth.js
@@ -48,7 +48,7 @@ router.post('/login', async (req, res, next) => {
         return res.status(400).send('EMPTY_FIELDS');
     }
 
-    axios.post('http://localhost:3000/autenticacoes/usuarios/login', {
+    axios.post('/autenticacoes/usuarios/login', {
         email: email,
         senha: password
     }, {
@@ -169,7 +169,7 @@ router.get('/logout', async (req, res, next) => {
     // console.log(userAccessToken);
     // return res.status(200).send('Oi');
 
-    axios.delete('http://localhost:3000/autenticacoes/usuarios/logout', {
+    axios.delete('/autenticacoes/usuarios/logout', {
         headers: {
             'Authorization': `Bearer ${userAccessToken}`
         },

--- a/server/index.js
+++ b/server/index.js
@@ -24,7 +24,7 @@
     app.use(
         cors({
             credentials: true,                  // Se withCredentials for passado
-            origin: 'http://localhost:4001'     // A request origin tem que ser válida.
+            origin: 'http://localhost:4001'     // A request origin tem que ser válida (e nesse caso, só receberemos requests do domínio do nosso próprio front-end).
 
             // credentials permite a análise e transição de cookies nas requests/responses.
             // O front-end deve informar que a requisição será feita com credentials, e o server deve aceitar essas credentials.


### PR DESCRIPTION
• Agora a instância do axios, o cliente http que utilizamos está configurada para possuir uma url base de chamadas padrão, aumentando assim a manutenibilidade do código ao centralizar o endereço de chamada principal e permitir a rápida identificação de chamadas que são feitas à domínios que diferem do padrão.